### PR TITLE
Fix some bugs discovered when testing the sample code

### DIFF
--- a/basic_json.hpp
+++ b/basic_json.hpp
@@ -1216,7 +1216,7 @@ namespace bizwen
 		{
 			rollbacker_map_all_ rollbacker(obj);
 			alloc_guard_<object_type> guard(*this);
-			stor().arr_ = new (guard.get()) object_type(std::move(obj));
+			stor().obj_ = new (guard.get()) object_type(std::move(obj));
 			guard.release();
 			rollbacker.release();
 			kind(kind_t::object);
@@ -1426,7 +1426,7 @@ namespace bizwen
 				for (auto& value : arr)
 				{
 					arr_.reserve(N);
-					arr.push_back(std::move(value));
+					arr_.push_back(std::move(value));
 				}
 
 				return arr_;

--- a/basic_json.hpp
+++ b/basic_json.hpp
@@ -908,7 +908,7 @@ namespace bizwen
 			return typename traits_t::template rebind_alloc<T>(node_).deallocate(p, 1);
 		}
 
-		void destroy() noexcept
+		constexpr void destroy() noexcept
 		{
 			auto k = kind();
 			auto& s = stor();

--- a/basic_json.hpp
+++ b/basic_json.hpp
@@ -312,7 +312,7 @@ namespace bizwen
 			bool is_string = string();
 			bool is_empty = empty();
 
-			if (!is_string || !is_empty)
+			if (!is_string && !is_empty)
 				throw std::runtime_error("json error: current value is not empty or not a string.");
 
 			if (is_string)
@@ -335,7 +335,7 @@ namespace bizwen
 			bool is_string = string();
 			bool is_empty = empty();
 
-			if (!is_string || !is_empty)
+			if (!is_string && !is_empty)
 				throw std::runtime_error("json error: current value is not empty or not a string.");
 
 			if (is_string)
@@ -358,7 +358,7 @@ namespace bizwen
 			bool is_string = string();
 			bool is_empty = empty();
 
-			if (!is_string || !is_empty)
+			if (!is_string && !is_empty)
 				throw std::runtime_error("json error: current value is not empty or not a string.");
 
 			if (is_string)
@@ -384,7 +384,7 @@ namespace bizwen
 			bool is_string = string();
 			bool is_empty = empty();
 
-			if (!is_string || !is_empty)
+			if (!is_string && !is_empty)
 				throw std::runtime_error("json error: current value is not empty or not a string.");
 
 			if (is_string)
@@ -407,7 +407,7 @@ namespace bizwen
 			bool is_null = null();
 			bool is_empty = empty();
 
-			if (!is_null || !is_empty)
+			if (!is_null && !is_empty)
 				throw std::runtime_error("json error: current value is not empty or not null.");
 
 			if (is_empty)

--- a/basic_json.hpp
+++ b/basic_json.hpp
@@ -1226,12 +1226,12 @@ namespace bizwen
 		{
 			kind(kind_t{});
 			stor() = stor_t{};
-			reinterpret_cast<node_type&>(*this) = std::move(n);
+			node_ = std::move(n);
 		}
 
 		[[nodiscard("discard nodes will cause leaks")]] constexpr operator node_type() && noexcept
 		{
-			auto node = reinterpret_cast<node_type&>(*this);
+			auto node = node_;
 			kind(kind_t{});
 			stor() = {};
 
@@ -1312,7 +1312,7 @@ namespace bizwen
 					auto const& [rkey, rvalue] = *first;
 					basic_json temp;
 					temp.clone(reinterpret_cast<basic_json const&>(rvalue));
-					lobj.emplace(rkey, reinterpret_cast<node_type&&>(std::move(temp)));
+					lobj.emplace(rkey, std::move(temp.node_));
 				}
 
 				rollbacker.release();


### PR DESCRIPTION
- Fix bad condition on throwing exceptions.
- Fix bad LHS operands.
- Trivially remove 3 improper occurrences of `reinterpret_cast`. It's not trivial to remove the rest, I'll do later.
- Add missed `constexpr` to `basic_json::destroy`.

I locally tested the [sample code](https://github.com/YexuanXiao/basic_json/blob/b9eb0038a8d40aa1216741a55546d48e0852892a/usecases.cpp) with
- `constexpr`-ized `std::map`,
- workaround for [P2169R4](https://wg21.link/p2169r4), and
- workaround for [P2747R2](https://wg21.link/p2747r2).

It seems a bit non-trivial to correctly use placement new in generic codes - `new (p) T(args)` may selects a user-defined overload, and we may need to use `::new ((void*)p) T(args)` instead. Note that `std::construct_at` is already doing the right thing.