### PR TITLE
Slicing functions should be `noexcept`

### DIFF
--- a/basic_json.hpp
+++ b/basic_json.hpp
@@ -1346,12 +1346,12 @@ namespace bizwen
 			destroy();
 		}
 
-		constexpr slice_type slice()
+		constexpr slice_type slice() noexcept
 		{
 			return *this;
 		}
 
-		constexpr const_slice_type slice() const
+		constexpr const_slice_type slice() const noexcept
 		{
 			return *this;
 		}


### PR DESCRIPTION
As the corresponding constructors of the slice types are already `noexcept`.