### PR TITLE
Implement move assignment by more thorough swapping

### DIFF
--- a/basic_json.hpp
+++ b/basic_json.hpp
@@ -1830,7 +1830,10 @@ namespace bizwen
 			else if constexpr (is_pocma_)
 			{
 				rhs.swap_without_ator(*this);
+				// N.B. ADL-swap may be ill-formed or have undesired effect
+				auto tmp_ator = std::move(node_.get_allocator_ref());
 				node_.get_allocator_ref() = std::move(rhs.node_.get_allocator_ref());
+				rhs.node_.get_allocator_ref() = std::move(tmp_ator);
 			}
 			else
 			{


### PR DESCRIPTION
The states of allocators also need to be swapped. Note that only move construction and move assignment are used here, which is guaranteed by the _Cpp17Allocator_ requirements, while ADL-found `swap` isn't guaranteed to be well-formed in this case.